### PR TITLE
fix(catalog): correct POPULAR_ORGANIZATIONS / POPULAR_DATASETS slugs that 404 on data.gov.il

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,18 +11,18 @@ export const DEFAULT_LIMITS = {
 
 export const POPULAR_DATASETS = [
   "branches",
-  "jerusalem-municipality-budget",
+  "beer-sheva-municipality-budget-7",
   "mechir-lamishtaken",
   "traffic-counts",
   "population-and-recipients-of-benefits-under-settlement-2012",
 ] as const;
 
 export const POPULAR_ORGANIZATIONS = [
-  "ministry-of-health",
-  "tel-aviv-yafo",
-  "jerusalem",
-  "cbs",
-  "ministry-of-finance",
+  "ministry-health",
+  "haifa",
+  "beer-sheva",
+  "lamas",
+  "mof",
 ] as const;
 
 /** Known-good resource IDs used in documentation and tests. */
@@ -36,7 +36,7 @@ export const EXAMPLE_RESOURCE_IDS = {
 export const RESOURCE_URI_SCHEME = "datagov" as const;
 
 /** User-Agent header sent to the CKAN API. */
-export const USER_AGENT = "data-gov-il-mcp/3.0 (+https://github.com/DavidOsherProceed/data-gov-il-mcp)" as const;
+export const USER_AGENT = "data-gov-il-mcp/3.0 (+https://github.com/DavidOsherdiagnostica/data-gov-il-mcp)" as const;
 
 export const SORT_OPTIONS = {
   newest: "metadata_created desc",


### PR DESCRIPTION
## Problem

Several hardcoded slugs in `src/config/constants.ts` don't exist on the live data.gov.il CKAN API and return **HTTP 404 / `success:false`**. I verified each one with `GET https://data.gov.il/api/3/action/{organization_show,package_show}?id=<slug>`.

### `POPULAR_ORGANIZATIONS` — all 5 were invalid
| old slug | result | corrected slug | org |
|---|---|---|---|
| `ministry-of-health` | 404 | `ministry-health` | משרד הבריאות |
| `tel-aviv-yafo` | 404 (no TLV org on data.gov.il) | `haifa` | עיריית חיפה |
| `jerusalem` | 404 (no JLM org on data.gov.il) | `beer-sheva` | עיריית באר שבע |
| `cbs` | 404 | `lamas` | הלשכה המרכזית לסטטיסטיקה (CBS) |
| `ministry-of-finance` | 404 | `mof` | משרד האוצר |

data.gov.il has no Tel Aviv or Jerusalem **organization**, so those two are swapped for real municipalities (Haifa, Beer Sheva) to keep the original "2 ministries + 2 big cities + stats bureau" shape. All five corrected slugs return `success:true`.

### `POPULAR_DATASETS` — 1 of 5 was invalid
| old slug | result | corrected slug |
|---|---|---|
| `jerusalem-municipality-budget` | 404 | `beer-sheva-municipality-budget-7` (תקציב עיריית באר-שבע) |

The other four (`branches`, `mechir-lamishtaken`, `traffic-counts`, `population-and-recipients-of-benefits-under-settlement-2012`) resolve fine and are unchanged.

### Bonus: `USER_AGENT` self-URL typo
`USER_AGENT` pointed at `github.com/DavidOsherProceed/data-gov-il-mcp` — that org doesn't exist. Corrected to `DavidOsherdiagnostica/data-gov-il-mcp`.

## How verified
Every corrected slug was checked against the live API (GET, the same method the `CkanClient` already uses). Example:
```
GET https://data.gov.il/api/3/action/organization_show?id=ministry-health   → 200 success:true
GET https://data.gov.il/api/3/action/organization_show?id=ministry-of-health → 404 success:false
```

## Scope
Single file, constants only — no behavior/logic change. `FEATURED` catalog (dataset names + `resource_id`s) was separately verified and is **not** affected (all entries still resolve).

---
Found while building a data.gov.il integration on top of this MCP — thanks for the clean, well-structured server. 🙏